### PR TITLE
fix: duplicate check & update of tun/agent map key after renaming

### DIFF
--- a/internal/core/agents/agentlist.go
+++ b/internal/core/agents/agentlist.go
@@ -67,7 +67,15 @@ func (agents *Agents) Rename(oldAlias, newAlias string) error {
 		return errors.New("agent not found")
 	}
 
+	if _, ok := agents.active[newAlias]; ok {
+		return errors.New("new agent alias already exists")
+	}
+
 	events.EventStream <- events.Event{Type: events.AgentRenamed, Data: *agent}
+
+	agents.active[newAlias] = agent
+	delete(agents.active, oldAlias)
+
 	agent.Alias = newAlias
 
 	return nil


### PR DESCRIPTION
This pull request introduces 2 bug fixes:
1. During creation and renaming of tun, it is not checked if specified alias already exists. 
2. Tun/agent map key is not updated during renaming, only corresponding field in tun/agent object is changed. 