### PR TITLE
Add option to ignore agent certificate

### DIFF
--- a/artifacts/agent/agent.go
+++ b/artifacts/agent/agent.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
+	"flag"
 	"fmt"
 	"io"
 	"net"
@@ -50,6 +51,10 @@ func main() {
 	var CACert = []byte(`{{ .CACert }}`)
 	var ignoreEnvProxy, _ = strconv.ParseBool(`{{ .IgnoreEnvProxy }}`)
 
+	flag.Usage = func() {}
+	var insecure = flag.Bool("insecure", false, "")
+	flag.Parse()
+
 	var conn net.Conn
 	redirectorMap = make(map[string]relay.Redirector)
 
@@ -87,8 +92,11 @@ func main() {
 					if options.Roots == nil {
 						return errors.New("no root certificate")
 					}
-					if _, err := cert.Verify(options); err != nil {
-						return err
+
+					if !*insecure {
+						if _, err := cert.Verify(options); err != nil {
+							return err
+						}
 					}
 
 					return nil

--- a/cmd/server/agents/agents.go
+++ b/cmd/server/agents/agents.go
@@ -46,8 +46,13 @@ func Run(config *config.Config, certService *certificate.CertificateService, ses
 		quit:           make(chan error, 1),
 	}
 
+	var clientAuth = tls.RequireAndVerifyClientCert
+	if config.InsecureAgents {
+		clientAuth = tls.NoClientCert
+	}
+
 	tlsConfig := &tls.Config{
-		ClientAuth:         tls.RequireAndVerifyClientCert,
+		ClientAuth:         clientAuth,
 		Certificates:       []tls.Certificate{tlsCert},
 		ClientCAs:          certpool,
 		RootCAs:            certpool,
@@ -66,6 +71,7 @@ func Run(config *config.Config, certService *certificate.CertificateService, ses
 			if options.Roots == nil {
 				return errors.New("no root certificate")
 			}
+
 			if _, err := cert.Verify(options); err != nil {
 				return err
 			}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -26,6 +26,7 @@ func main() {
 	var maxInflight = flag.Int("max-inflight", 4096, "max inflight TCP connections")
 	var maxConnectionHandler = flag.Int("max-connection", 1024, "per tunnel connection pool size")
 	var operatorAddr = flag.String("operator-addr", "0.0.0.0:58008", "Address for operators connections")
+	var insecureAgents = flag.Bool("insecure-agents", false, "Disable certificate verification for agents (insecure!)")
 
 	flag.Parse()
 
@@ -53,6 +54,7 @@ func main() {
 		MaxInFlight:          *maxInflight,
 		MaxConnectionHandler: *maxConnectionHandler,
 		OperatorAddr:         *operatorAddr,
+		InsecureAgents:       *insecureAgents,
 	}
 
 	db, err := storage.New(cfg.GetStorageDir())

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 
 require (
 	github.com/gdamore/tcell/v2 v2.8.1
+	github.com/google/uuid v1.6.0
 	github.com/rivo/tview v0.0.0-20240807205129-e4c497cc59ed
 	github.com/rs/xid v1.6.0
 	github.com/vishvananda/netlink v1.3.0
@@ -24,7 +25,6 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/gdamore/encoding v1.0.1 // indirect
 	github.com/google/btree v1.1.3 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	MaxInFlight          int
 	MaxConnectionHandler int
 	OperatorAddr         string
+	InsecureAgents       bool
 }
 
 func (cfg *Config) GetRootAppDir() string {


### PR DESCRIPTION
Mainly for people passing OffSec exams as they
appear to employ some form of DPI which does not
play well with mTLS. Not 100% sure about that,
but will probably help some people

Solves #16 