### PR TITLE
feat(tui): add FreeBSD as GOOS option in agent generate form

### DIFF
--- a/cmd/client/tui/forms/generate.go
+++ b/cmd/client/tui/forms/generate.go
@@ -111,7 +111,7 @@ func NewGenerateForm() *GenerateForm {
 	goosField.SetFocusFunc(func() {
 		hintBox.SetText(generate_goos.Hint)
 	})
-	goosField.SetOptions([]string{"Windows", "Linux", "Darwin"}, func(option string, index int) {
+	goosField.SetOptions([]string{"Windows", "Linux", "FreeBSD", "Darwin"}, func(option string, index int) {
 		generate_goos.Last.ID = index
 		generate_goos.Last.Value = strings.ToLower(option)
 	})


### PR DESCRIPTION
Just added FreeBSD as a selectable option in the agent generate form, so you can now build for FreeBSD right from the TUI like the other platforms.

✅ Tested and works as expected.