### PR TITLE
add 'all' target in Makefile as per documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,3 +81,6 @@ install:
 .PHONY: service
 service:
 	./install_service.sh
+
+.PHONY: all
+all: agent server client


### PR DESCRIPTION
Hello, 

Thank you for your work on this tool.

While browsing the Wiki, I noticed in the [Multiplayer > Server > Building from sources > Quick build](https://github.com/ttpreport/ligolo-mp/wiki/server-build-sources) section that there should be an all target in the Makefile, which currently doesn’t exist.

Regards,