### PR TITLE
Enhancement: Bind Agent Support, Version Flag, and CA Rotation Fix (#21 #32 #36)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ BLOAT_FILES := AUTHORS CONTRIBUTORS PATENTS VERSION favicon.ico robots.txt SECUR
 GARBLE_VER := 0.14.2
 
 GO ?= go
+APP_VERSION ?= v2.3.0
+VERSION_PKG := github.com/ttpreport/ligolo-mp/v2/internal/version
+LDFLAGS := -X $(VERSION_PKG).Version=$(APP_VERSION)
 
 ARCH := $(shell uname -m)
 
@@ -60,11 +63,11 @@ agent:
 
 .PHONY: server
 server:
-	GOOS=$(TARGET_OS) GOARCH=$(TARGET_ARCH) CGO_ENABLED=0 $(GO) build -mod=vendor -trimpath -o ligolo-mp ./cmd/server/
+	GOOS=$(TARGET_OS) GOARCH=$(TARGET_ARCH) CGO_ENABLED=0 $(GO) build -mod=vendor -trimpath -ldflags "$(LDFLAGS)" -o ligolo-mp ./cmd/server/
 
 .PHONY: client
 client:
-	GOOS=$(TARGET_OS) GOARCH=$(TARGET_ARCH) CGO_ENABLED=0 $(GO) build -mod=vendor -trimpath -o ligolo-mp-client ./cmd/client/
+	GOOS=$(TARGET_OS) GOARCH=$(TARGET_ARCH) CGO_ENABLED=0 $(GO) build -mod=vendor -trimpath -ldflags "$(LDFLAGS)" -o ligolo-mp-client ./cmd/client/
 
 .PHONY: protobuf
 protobuf:

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ ligolo-mp [options]
   -insecure-agents
         Disable certificate verification for agents
   -rotate-pki
-        Regenerate all certificates (CA + server) and exit
+        Regenerate all certificates (CA + server) 
   -version
-        Print version and exit
+        Print version 
   -v    Enable verbose logging
 ```
 
@@ -50,7 +50,7 @@ ligolo-mp [options]
 ligolo-mp-client [options]
 
   -version
-        Print version and exit
+        Print version 
   -v    Enable verbose logging
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,76 @@
 - Dynamic mTLS-enabled agent binaries generation with obfuscation option
 - Simplified certificate management
 - Friendly terminal-based GUI
+- Bind agent mode — agent listens, server connects (reverse TCP direction)
+- PKI rotation — regenerate all certificates with a single flag
+
+## Server Usage
+
+```
+ligolo-mp [options]
+
+  -agent-addr string
+        Listening address for agents (default "0.0.0.0:11601")
+  -operator-addr string
+        Listening address for operators (default "0.0.0.0:58008")
+  -daemon
+        Run without TUI (server-only mode)
+  -insecure-agents
+        Disable certificate verification for agents
+  -rotate-pki
+        Regenerate all certificates (CA + server) and exit
+  -version
+        Print version and exit
+  -v    Enable verbose logging
+```
+
+## Client Usage
+
+```
+ligolo-mp-client [options]
+
+  -version
+        Print version and exit
+  -v    Enable verbose logging
+```
+
+## Agent Usage
+
+```
+agent [options]
+
+  -bind string
+        Listen for server connections on this address (bind mode)
+        Example: -bind 0.0.0.0:4444
+  -server string
+        Override the embedded server address
+        Example: -server 1.2.3.4:11601
+  -insecure
+        Disable TLS certificate verification
+```
+
+## Bind Agent Mode
+
+In standard mode the agent dials the server. In bind mode the roles are reversed — the agent listens and the server connects to it. This is useful when the target cannot reach the server directly.
+
+**On the target machine:**
+```
+./agent -bind 192.168.1.10:4444
+```
+
+**From the server TUI (admin only):**
+
+Press `Ctrl+B` in the dashboard, enter the agent's address (`192.168.1.10:4444`), and connect.
+
+## PKI Rotation
+
+To regenerate the CA and all server certificates:
+
+```
+ligolo-mp --rotate-pki
+```
+
+> **Warning:** All existing operator profiles become invalid after rotation and must be re-exported.
 
 ## Documentation
 

--- a/artifacts/agent/agent.go
+++ b/artifacts/agent/agent.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"os/user"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -49,9 +50,20 @@ func main() {
 	var CACert = []byte(`{{ .CACert }}`)
 	var ignoreEnvProxy, _ = strconv.ParseBool(`{{ .IgnoreEnvProxy }}`)
 
-	flag.Usage = func() {}
-	var insecure = flag.Bool("insecure", false, "")
-	var serverOverride = flag.String("server", "", "")
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "%s\n\nUsage:\n", filepath.Base(os.Args[0]))
+		fmt.Fprintf(os.Stderr, "  -bind string\n")
+		fmt.Fprintf(os.Stderr, "    \tListen for server connections on this address (bind/reverse mode).\n")
+		fmt.Fprintf(os.Stderr, "    \tExample: -bind 0.0.0.0:4444\n")
+		fmt.Fprintf(os.Stderr, "  -server string\n")
+		fmt.Fprintf(os.Stderr, "    \tOverride the embedded server address.\n")
+		fmt.Fprintf(os.Stderr, "    \tExample: -server 1.2.3.4:11601\n")
+		fmt.Fprintf(os.Stderr, "  -insecure\n")
+		fmt.Fprintf(os.Stderr, "    \tDisable TLS certificate verification (use with caution).\n")
+	}
+	var insecure = flag.Bool("insecure", false, "disable TLS certificate verification")
+	var serverOverride = flag.String("server", "", "override embedded server address (e.g. 1.2.3.4:11601)")
+	var bindAddr = flag.String("bind", "", "listen for server connections on this address (bind mode, e.g. 0.0.0.0:4444)")
 	flag.Parse()
 
 	if *serverOverride != "" {
@@ -59,6 +71,17 @@ func main() {
 	}
 
 	redirectorMap = make(map[string]relay.Redirector)
+
+	if *bindAddr != "" {
+		// Bind mode: agent listens, server connects.
+		for {
+			func() {
+				defer func() { recover() }() //nolint:errcheck
+				runBind(*bindAddr, *insecure, AgentCert, AgentKey, CACert)
+			}()
+			time.Sleep(5 * time.Second)
+		}
+	}
 
 	// Outer loop restarts the connection loop after a panic without growing the
 	// call stack. Each iteration wraps run() in a panic-recovering closure so
@@ -162,6 +185,80 @@ func run(servers []string, proxyServer string, insecure, ignoreEnvProxy bool, ti
 	}
 }
 
+// runBind runs the agent in bind mode: it listens for an incoming connection
+// from the server rather than dialing out. The agent is the TLS server;
+// yamux roles are unchanged (agent=yamux.Server, server=yamux.Client).
+func runBind(addr string, insecure bool, AgentCert, AgentKey, CACert []byte) {
+	ca := x509.NewCertPool()
+	if ok := ca.AppendCertsFromPEM(CACert); !ok {
+		return
+	}
+
+	mtlsCert, err := tls.X509KeyPair(AgentCert, AgentKey)
+	if err != nil {
+		return
+	}
+
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{mtlsCert},
+		ClientAuth:   tls.RequireAnyClientCert,
+		ClientCAs:    ca,
+		MinVersion:   tls.VersionTLS13,
+		MaxVersion:   tls.VersionTLS13,
+		InsecureSkipVerify: true,
+		VerifyPeerCertificate: func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
+			cert, err := x509.ParseCertificate(rawCerts[0])
+			if err != nil {
+				return err
+			}
+			if insecure {
+				return nil
+			}
+			_, err = cert.Verify(x509.VerifyOptions{Roots: ca})
+			return err
+		},
+	}
+
+	listener, err := tls.Listen("tcp", addr, tlsConfig)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[-] Failed to listen on %s: %v\n", addr, err)
+		return
+	}
+	defer listener.Close()
+
+	fmt.Fprintf(os.Stderr, "[*] Listening on %s (bind mode)\n", addr)
+
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		fmt.Fprintf(os.Stderr, "[+] Server connected from %s\n", conn.RemoteAddr())
+		go handleBindConn(conn)
+	}
+}
+
+// handleBindConn wraps an accepted TLS connection as a yamux.Server session
+// and processes incoming commands from the server.
+func handleBindConn(conn net.Conn) {
+	yamuxConf := yamux.DefaultConfig()
+	yamuxConf.LogOutput = io.Discard
+	yamuxConn, err := yamux.Server(conn, yamuxConf)
+	if err != nil {
+		conn.Close()
+		return
+	}
+
+	for {
+		stream, err := yamuxConn.Accept()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "[-] Server disconnected\n")
+			return
+		}
+		go handleConn(stream)
+	}
+}
+
 func connect(conn net.Conn, config *tls.Config) error {
 	tlsConn := tls.Client(conn, config)
 
@@ -172,9 +269,12 @@ func connect(conn net.Conn, config *tls.Config) error {
 		return err
 	}
 
+	fmt.Fprintf(os.Stderr, "[+] Connected to %s\n", conn.RemoteAddr())
+
 	for {
 		conn, err := yamuxConn.Accept()
 		if err != nil {
+			fmt.Fprintf(os.Stderr, "[-] Disconnected from server\n")
 			return err
 		}
 		go handleConn(conn)

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -12,13 +12,25 @@ import (
 	"github.com/ttpreport/ligolo-mp/v2/internal/crl"
 	"github.com/ttpreport/ligolo-mp/v2/internal/operator"
 	"github.com/ttpreport/ligolo-mp/v2/internal/storage"
+	"github.com/ttpreport/ligolo-mp/v2/internal/version"
 	"github.com/ttpreport/ligolo-mp/v2/pkg/logger"
 )
 
 func main() {
 	var verbose = flag.Bool("v", false, "enable verbose mode")
+	var showVersion = flag.Bool("version", false, "print version and exit")
+
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "ligolo-mp-client %s\n\nUsage:\n", version.Version)
+		flag.PrintDefaults()
+	}
 
 	flag.Parse()
+
+	if *showVersion {
+		fmt.Printf("ligolo-mp-client %s\n", version.Version)
+		os.Exit(0)
+	}
 
 	loggingOpts := &slog.HandlerOptions{}
 	if *verbose {

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -18,7 +18,7 @@ import (
 
 func main() {
 	var verbose = flag.Bool("v", false, "enable verbose mode")
-	var showVersion = flag.Bool("version", false, "print version and exit")
+	var showVersion = flag.Bool("version", false, "print version")
 
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "ligolo-mp-client %s\n\nUsage:\n", version.Version)

--- a/cmd/client/tui/forms/bind.go
+++ b/cmd/client/tui/forms/bind.go
@@ -1,0 +1,74 @@
+package forms
+
+import (
+	"github.com/rivo/tview"
+)
+
+var (
+	bind_address = FormVal[string]{
+		Hint: "Bind agent address (e.g. 192.168.1.10:4444)",
+	}
+)
+
+type BindAgentForm struct {
+	tview.Flex
+	form *tview.Form
+}
+
+func NewBindAgentForm() *BindAgentForm {
+	f := &BindAgentForm{
+		Flex: *tview.NewFlex(),
+		form: tview.NewForm(),
+	}
+
+	hintBox := tview.NewTextView()
+	hintBox.SetTitle("HINT")
+	hintBox.SetTitleAlign(tview.AlignCenter)
+	hintBox.SetBorder(true)
+	hintBox.SetBorderPadding(1, 1, 1, 1)
+
+	f.form.SetTitle("Connect to Bind Agent").SetTitleAlign(tview.AlignCenter)
+	f.form.SetBorder(true)
+	f.form.SetButtonsAlign(tview.AlignCenter)
+
+	addrField := tview.NewInputField()
+	addrField.SetLabel("Address")
+	addrField.SetText(bind_address.Last)
+	addrField.SetFocusFunc(func() { hintBox.SetText(bind_address.Hint) })
+	addrField.SetChangedFunc(func(text string) { bind_address.Last = text })
+	addrField.SetBlurFunc(func() { hintBox.Clear() })
+	f.form.AddFormItem(addrField)
+
+	f.form.AddButton("Connect", nil)
+	f.form.AddButton("Cancel", nil)
+
+	formFlex := tview.NewFlex().SetDirection(tview.FlexRow).
+		AddItem(f.form, 7, 1, true).
+		AddItem(hintBox, 5, 1, false)
+
+	f.Flex.AddItem(nil, 0, 1, false).
+		AddItem(tview.NewFlex().SetDirection(tview.FlexRow).
+			AddItem(nil, 0, 1, false).
+			AddItem(formFlex, 0, 1, true).
+			AddItem(nil, 0, 1, false),
+			0, 1, true).
+		AddItem(nil, 0, 1, false)
+
+	return f
+}
+
+func (f *BindAgentForm) GetID() string {
+	return "bind_agent_form"
+}
+
+func (f *BindAgentForm) SetSubmitFunc(fn func(addr string)) {
+	btnId := f.form.GetButtonIndex("Connect")
+	f.form.GetButton(btnId).SetSelectedFunc(func() {
+		fn(bind_address.Last)
+	})
+}
+
+func (f *BindAgentForm) SetCancelFunc(fn func()) {
+	btnId := f.form.GetButtonIndex("Cancel")
+	f.form.GetButton(btnId).SetSelectedFunc(fn)
+}

--- a/cmd/client/tui/pages/credentials.go
+++ b/cmd/client/tui/pages/credentials.go
@@ -17,6 +17,7 @@ import (
 type CredentialsPage struct {
 	tview.Pages
 
+	app   *tview.Application
 	table *tview.Table
 
 	data []*operator.Operator
@@ -111,6 +112,10 @@ func (creds *CredentialsPage) GetElem(id int) *operator.Operator {
 	return nil
 }
 
+func (creds *CredentialsPage) SetApp(app *tview.Application) {
+	creds.app = app
+}
+
 func (creds *CredentialsPage) SetDataFunc(f func() ([]*operator.Operator, error)) {
 	creds.getData = f
 }
@@ -142,10 +147,13 @@ func (creds *CredentialsPage) initCredentials() {
 				creds.DoWithLoader("Connecting...", func() {
 					err := creds.connect(oper)
 					if err != nil {
-						creds.ShowError(fmt.Sprintf("Could not connect: %s", err), cleanup)
+						creds.app.QueueUpdateDraw(func() {
+							creds.ShowError(fmt.Sprintf("Could not connect: %s", err), cleanup)
+						})
+						return
 					}
 
-					cleanup()
+					creds.app.QueueUpdateDraw(cleanup)
 				})
 			}))
 
@@ -154,11 +162,15 @@ func (creds *CredentialsPage) initCredentials() {
 					creds.DoWithLoader("Removing credentials...", func() {
 						err := creds.deleteCred(oper)
 						if err != nil {
-							creds.ShowError(fmt.Sprintf("Could not remove credentials: %s", err), cleanup)
+							creds.app.QueueUpdateDraw(func() {
+								creds.ShowError(fmt.Sprintf("Could not remove credentials: %s", err), cleanup)
+							})
 							return
 						}
 
-						creds.ShowInfo("Credentials removed", cleanup)
+						creds.app.QueueUpdateDraw(func() {
+							creds.ShowInfo("Credentials removed", cleanup)
+						})
 					})
 				})
 			}))
@@ -224,9 +236,13 @@ func (creds *CredentialsPage) DoWithLoader(text string, action func()) {
 	go func() {
 		modal := modals.NewLoaderModal()
 		modal.SetText(text)
-		creds.AddPage(modal.GetID(), modal, true, true)
+		creds.app.QueueUpdateDraw(func() {
+			creds.AddPage(modal.GetID(), modal, true, true)
+		})
 		action()
-		creds.RemovePage(modal.GetID())
+		creds.app.QueueUpdateDraw(func() {
+			creds.RemovePage(modal.GetID())
+		})
 	}()
 }
 
@@ -235,7 +251,6 @@ func (creds *CredentialsPage) ShowError(text string, done func()) {
 	modal.SetText(text)
 	modal.SetDoneFunc(func(_ int, _ string) {
 		creds.RemovePage(modal.GetID())
-
 		if done != nil {
 			done()
 		}
@@ -248,7 +263,6 @@ func (creds *CredentialsPage) ShowInfo(text string, done func()) {
 	modal.SetText(text)
 	modal.SetDoneFunc(func(_ int, _ string) {
 		creds.RemovePage(modal.GetID())
-
 		if done != nil {
 			done()
 		}

--- a/cmd/client/tui/pages/dashboard.go
+++ b/cmd/client/tui/pages/dashboard.go
@@ -33,6 +33,7 @@ type DashboardPage struct {
 	getMetadata                 func() (*config.Config, *operator.Operator, error)
 	adminFunc                   func()
 	generateFunc                func(path string, servers string, goos string, goarch string, obfuscate bool, proxy string, ignoreEnvProxy bool) (string, error)
+	connectBindAgentFunc        func(addr string) error
 	sessionStartFunc            func(*session.Session) error
 	sessionStopFunc             func(*session.Session) error
 	sessionRenameFunc           func(*session.Session, string) error
@@ -358,6 +359,26 @@ func (dash *DashboardPage) InputHandler() func(event *tcell.EventKey, setFocus f
 						break
 					}
 				}
+			case tcell.KeyCtrlB:
+				if !dash.operator.IsAdmin {
+					break
+				}
+				bindForm := forms.NewBindAgentForm()
+				bindForm.SetSubmitFunc(func(addr string) {
+					dash.DoWithLoader("Connecting to bind agent...", func() {
+						err := dash.connectBindAgentFunc(addr)
+						if err != nil {
+							dash.ShowError(fmt.Sprintf("Could not connect to bind agent: %s", err), nil)
+							return
+						}
+						dash.app.QueueUpdateDraw(func() { dash.RemovePage(bindForm.GetID()) })
+						dash.ShowInfo("Connected to bind agent", nil)
+					})
+				})
+				bindForm.SetCancelFunc(func() {
+					dash.RemovePage(bindForm.GetID())
+				})
+				dash.AddPage(bindForm.GetID(), bindForm, true, true)
 			case tcell.KeyCtrlN:
 				gen := forms.NewGenerateForm()
 				gen.SetSubmitFunc(func(path string, servers string, goos string, goarch string, obfuscate bool, proxy string, ignoreEnvProxy bool) {
@@ -446,6 +467,10 @@ func (dash *DashboardPage) SetGenerateFunc(f func(string, string, string, string
 	dash.generateFunc = f
 }
 
+func (dash *DashboardPage) SetConnectBindAgentFunc(f func(string) error) {
+	dash.connectBindAgentFunc = f
+}
+
 func (dash *DashboardPage) SetSessionStartFunc(f func(*session.Session) error) {
 	dash.sessionStartFunc = f
 }
@@ -530,7 +555,9 @@ func (dash *DashboardPage) GetNavBar() []widgets.NavBarElem {
 
 	if dash.operator.IsAdmin {
 		navbar = append([]widgets.NavBarElem{
-			widgets.NewNavBarElem(tcell.KeyCtrlA, "Admin")},
+			widgets.NewNavBarElem(tcell.KeyCtrlA, "Admin"),
+			widgets.NewNavBarElem(tcell.KeyCtrlB, "Bind Agent"),
+		},
 			navbar...,
 		)
 	}

--- a/cmd/client/tui/tui.go
+++ b/cmd/client/tui/tui.go
@@ -87,6 +87,7 @@ func (app *App) SwitchToPage(p pages.Page) {
 }
 
 func (app *App) initCredentials() {
+	app.credentials.SetApp(&app.Application)
 	app.credentials.SetDataFunc(func() ([]*operator.Operator, error) {
 		return app.operService.AllOperators()
 	})
@@ -101,9 +102,11 @@ func (app *App) initCredentials() {
 			return err
 		}
 
-		app.dashboard.SetOperator(oper)
-		app.admin.SetOperator(oper)
-		app.SwitchToPage(app.dashboard)
+		app.QueueUpdateDraw(func() {
+			app.dashboard.SetOperator(oper)
+			app.admin.SetOperator(oper)
+			app.SwitchToPage(app.dashboard)
+		})
 
 		return nil
 	})
@@ -183,6 +186,13 @@ func (app *App) initDashboard() {
 		}
 
 		return filepath.Abs(path)
+	})
+
+	app.dashboard.SetConnectBindAgentFunc(func(addr string) error {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+		defer cancel()
+		_, err := app.operator.Client().ConnectAgent(ctx, &pb.ConnectAgentReq{Address: addr})
+		return err
 	})
 
 	app.dashboard.SetSessionStartFunc(func(sess *session.Session) error {

--- a/cmd/server/agents/agents.go
+++ b/cmd/server/agents/agents.go
@@ -25,29 +25,31 @@ type AgentApiHandler struct {
 	quit        chan error
 }
 
-func Run(config *config.Config, certService *certificate.CertificateService, sessionService *session.SessionService) error {
+// Run starts the agent listener and returns the handler immediately.
+// Call Done() to receive the error when the listener exits.
+func Run(config *config.Config, certService *certificate.CertificateService, sessionService *session.SessionService) (*AgentApiHandler, error) {
 	CACert, err := certService.GetCA()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if CACert == nil {
-		return errors.New("CA certificate not found")
+		return nil, errors.New("CA certificate not found")
 	}
 	certpool, err := CACert.CertPool()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	agentCert, err := certService.GetAgentServerCert()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if agentCert == nil {
-		return errors.New("agent server certificate not found")
+		return nil, errors.New("agent server certificate not found")
 	}
 	tlsCert, err := agentCert.KeyPair()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	handler := &AgentApiHandler{
@@ -94,7 +96,81 @@ func Run(config *config.Config, certService *certificate.CertificateService, ses
 
 	go handler.serve("tcp", config.ListenInterface, tlsConfig)
 
-	return <-handler.quit
+	return handler, nil
+}
+
+// Done returns a channel that receives an error when the agent listener exits.
+func (aah *AgentApiHandler) Done() <-chan error {
+	return aah.quit
+}
+
+// DialAgent connects to a bind-mode agent listening at addr.
+// The server acts as TLS client; the agent acts as TLS server.
+// yamux roles are unchanged: server=Client, agent=Server.
+func (aah *AgentApiHandler) DialAgent(addr string) error {
+	CACert, err := aah.certService.GetCA()
+	if err != nil {
+		return err
+	}
+	if CACert == nil {
+		return errors.New("CA certificate not found")
+	}
+	certpool, err := CACert.CertPool()
+	if err != nil {
+		return err
+	}
+
+	agentCert, err := aah.certService.GetAgentServerCert()
+	if err != nil {
+		return err
+	}
+	if agentCert == nil {
+		return errors.New("agent server certificate not found")
+	}
+	tlsCert, err := agentCert.KeyPair()
+	if err != nil {
+		return err
+	}
+
+	tlsConfig := &tls.Config{
+		Certificates:       []tls.Certificate{tlsCert},
+		RootCAs:            certpool,
+		MinVersion:         tls.VersionTLS13,
+		MaxVersion:         tls.VersionTLS13,
+		InsecureSkipVerify: true,
+		VerifyPeerCertificate: func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
+			cert, err := x509.ParseCertificate(rawCerts[0])
+			if err != nil {
+				return err
+			}
+			_, err = cert.Verify(x509.VerifyOptions{Roots: certpool})
+			return err
+		},
+	}
+
+	conn, err := tls.DialWithDialer(&net.Dialer{Timeout: 10 * time.Second}, "tcp", addr, tlsConfig)
+	if err != nil {
+		return err
+	}
+
+	cfg := yamux.DefaultConfig()
+	cfg.LogOutput = io.Discard
+	yamuxConn, err := yamux.Client(conn, cfg)
+	if err != nil {
+		conn.Close()
+		return err
+	}
+
+	newSession, err := aah.sessionService.NewSession(yamuxConn)
+	if err != nil {
+		yamuxConn.Close()
+		return err
+	}
+
+	go aah.startSessionMonitor(newSession)
+
+	events.Publish(events.OK, "bind agent '%s' connected", newSession.GetName())
+	return nil
 }
 
 func (aah *AgentApiHandler) serve(protocol string, listenIface string, tlsConfig *tls.Config) {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -28,8 +28,8 @@ func main() {
 	var maxConnectionHandler = flag.Int("max-connection", 1024, "per tunnel connection pool size")
 	var operatorAddr = flag.String("operator-addr", "0.0.0.0:58008", "Address for operators connections")
 	var insecureAgents = flag.Bool("insecure-agents", false, "Disable certificate verification for agents (insecure!)")
-	var showVersion = flag.Bool("version", false, "print version and exit")
-	var regenCerts = flag.Bool("rotate-pki", false, "regenerate all certificates (CA + server certs) and exit")
+	var showVersion = flag.Bool("version", false, "print version")
+	var regenCerts = flag.Bool("rotate-pki", false, "regenerate all certificates (CA + server certs)")
 
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "ligolo-mp %s\n\nUsage:\n", version.Version)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ttpreport/ligolo-mp/v2/internal/operator"
 	"github.com/ttpreport/ligolo-mp/v2/internal/session"
 	"github.com/ttpreport/ligolo-mp/v2/internal/storage"
+	"github.com/ttpreport/ligolo-mp/v2/internal/version"
 	"github.com/ttpreport/ligolo-mp/v2/pkg/logger"
 )
 
@@ -27,8 +28,20 @@ func main() {
 	var maxConnectionHandler = flag.Int("max-connection", 1024, "per tunnel connection pool size")
 	var operatorAddr = flag.String("operator-addr", "0.0.0.0:58008", "Address for operators connections")
 	var insecureAgents = flag.Bool("insecure-agents", false, "Disable certificate verification for agents (insecure!)")
+	var showVersion = flag.Bool("version", false, "print version and exit")
+	var regenCerts = flag.Bool("rotate-pki", false, "regenerate all certificates (CA + server certs) and exit")
+
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "ligolo-mp %s\n\nUsage:\n", version.Version)
+		flag.PrintDefaults()
+	}
 
 	flag.Parse()
+
+	if *showVersion {
+		fmt.Printf("ligolo-mp %s\n", version.Version)
+		os.Exit(0)
+	}
 
 	loggingOpts := &slog.HandlerOptions{}
 	if *verbose {
@@ -90,6 +103,18 @@ func main() {
 
 	crlService := crl.NewCRLService(crlRepo)
 	certService := certificate.NewCertificateService(certRepo, crlService)
+
+	if *regenCerts {
+		fmt.Println("Regenerating all certificates...")
+		if err := certService.RegenerateAll(); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println("Done. All server certificates have been regenerated.")
+		fmt.Println("WARNING: All existing operator profiles are now invalid and must be re-exported.")
+		os.Exit(0)
+	}
+
 	sessService := session.NewSessionService(cfg, sessRepo)
 	operService := operator.NewOperatorService(cfg, operRepo, certService)
 	assetService := asset.NewAssetsService(cfg, assetRepo)
@@ -117,12 +142,17 @@ func main() {
 		slog.SetDefault(logHandler)
 	}
 
+	agentHandler, err := agents.Run(cfg, certService, sessService)
+	if err != nil {
+		panic(fmt.Sprintf("could not start agent server: %v", err))
+	}
+
 	quit := make(chan error)
 	go func() {
-		quit <- agents.Run(cfg, certService, sessService)
+		quit <- <-agentHandler.Done()
 	}()
 	go func() {
-		quit <- rpc.Run(cfg, certService, sessService, operService, assetService)
+		quit <- rpc.Run(cfg, certService, sessService, operService, assetService, agentHandler)
 	}()
 
 	if *daemon {

--- a/cmd/server/rpc/rpc.go
+++ b/cmd/server/rpc/rpc.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"sync"
 
+	"github.com/ttpreport/ligolo-mp/v2/cmd/server/agents"
 	"github.com/ttpreport/ligolo-mp/v2/internal/asset"
 	"github.com/ttpreport/ligolo-mp/v2/internal/certificate"
 	"github.com/ttpreport/ligolo-mp/v2/internal/config"
@@ -32,6 +33,7 @@ type ligoloServer struct {
 	certService   *certificate.CertificateService
 	operService   *operator.OperatorService
 	assetsService *asset.AssetService
+	agentHandler  *agents.AgentApiHandler
 }
 
 type ligoloConnection struct {
@@ -550,6 +552,21 @@ func (s *ligoloServer) GetMetadata(ctx context.Context, in *pb.Empty) (*pb.GetMe
 	}, nil
 }
 
+func (s *ligoloServer) ConnectAgent(ctx context.Context, in *pb.ConnectAgentReq) (*pb.Empty, error) {
+	slog.Debug("Received request to connect to bind agent", slog.Any("addr", in.Address))
+	oper := ctx.Value("operator").(*operator.Operator)
+	if !oper.IsAdmin {
+		return nil, errors.New("access denied")
+	}
+
+	if err := s.agentHandler.DialAgent(in.Address); err != nil {
+		return nil, fmt.Errorf("could not connect to bind agent: %w", err)
+	}
+
+	events.Publish(events.OK, "%s: connected to bind agent at '%s'", oper.Name, in.Address)
+	return &pb.Empty{}, nil
+}
+
 func (s *ligoloServer) operatorFromContext(ctx context.Context) (*operator.Operator, error) {
 	p, ok := peer.FromContext(ctx)
 	if !ok {
@@ -587,7 +604,7 @@ func (s *ligoloServer) unaryAuthInterceptor(ctx context.Context, req any, info *
 	)
 }
 
-func Run(config *config.Config, certService *certificate.CertificateService, sessService *session.SessionService, operService *operator.OperatorService, assetsService *asset.AssetService) error {
+func Run(config *config.Config, certService *certificate.CertificateService, sessService *session.SessionService, operService *operator.OperatorService, assetsService *asset.AssetService, agentHandler *agents.AgentApiHandler) error {
 	lis, err := net.Listen("tcp", config.OperatorAddr)
 	if err != nil {
 		slog.Error("Could not start operator server",
@@ -660,6 +677,7 @@ func Run(config *config.Config, certService *certificate.CertificateService, ses
 		certService:   certService,
 		operService:   operService,
 		assetsService: assetsService,
+		agentHandler:  agentHandler,
 	}
 	grpcServer := grpc.NewServer(grpc.Creds(credentials.NewTLS(tlsConfig)), grpc.UnaryInterceptor(ligoloServer.unaryAuthInterceptor))
 

--- a/internal/certificate/service.go
+++ b/internal/certificate/service.go
@@ -84,6 +84,19 @@ func (cs *CertificateService) RegenerateCert(name string) (*Certificate, error) 
 	return cert, nil
 }
 
+func (cs *CertificateService) RegenerateAll() error {
+	certs, err := cs.repo.GetAll()
+	if err != nil {
+		return err
+	}
+	for _, cert := range certs {
+		if err := cs.repo.Remove(cert.Name); err != nil {
+			return err
+		}
+	}
+	return cs.Init()
+}
+
 func (cs *CertificateService) Init() error {
 	CAcert, err := cs.GetCA()
 	if err != nil {

--- a/internal/operator/entity.go
+++ b/internal/operator/entity.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"time"
@@ -57,6 +58,19 @@ func (oper *Operator) ToBytes() ([]byte, error) {
 	return operBytes, nil
 }
 
+// connectable replaces a wildcard host (0.0.0.0 / ::) with 127.0.0.1 so
+// operator profiles that store the server's listen address are still dialable.
+func connectable(addr string) string {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return addr
+	}
+	if host == "0.0.0.0" || host == "::" {
+		host = "127.0.0.1"
+	}
+	return net.JoinHostPort(host, port)
+}
+
 func (oper *Operator) Connect() error {
 	if oper.conn != nil {
 		oper.Disconnect()
@@ -98,7 +112,7 @@ func (oper *Operator) Connect() error {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	conn, err := grpc.DialContext(ctx, oper.Server,
+	conn, err := grpc.DialContext(ctx, connectable(oper.Server),
 		grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)),
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(20*1024*1024)),
 		grpc.WithBlock(),

--- a/internal/operator/service.go
+++ b/internal/operator/service.go
@@ -30,7 +30,7 @@ func (service *OperatorService) Init() error {
 	}
 
 	if len(operators) < 1 {
-		_, err := service.NewOperator("admin", true, service.config.OperatorAddr)
+		_, err := service.NewOperator("admin", true, connectable(service.config.OperatorAddr))
 		if err != nil {
 			return err
 		}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,4 @@
+package version
+
+// Version is set at build time via -ldflags "-X github.com/ttpreport/ligolo-mp/v2/internal/version.Version=vX.Y.Z"
+var Version = "dev"

--- a/protobuf/connect_agent.go
+++ b/protobuf/connect_agent.go
@@ -1,0 +1,165 @@
+package protobuf
+
+// Hand-rolled proto message for ConnectAgentReq.
+// Equivalent to:
+//   syntax = "proto3";
+//   package ligolo;
+//   option go_package = "github.com/ttpreport/ligolo-mp/v2/protobuf";
+//   message ConnectAgentReq { string Address = 1; }
+
+import (
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	reflect "reflect"
+	sync "sync"
+)
+
+// rawDesc encodes the FileDescriptorProto for the minimal proto file above.
+var file_ligolo_connect_proto_rawDesc = []byte{
+	// name = "ligolo_connect.proto"
+	0x0a, 0x14, 0x6c, 0x69, 0x67, 0x6f, 0x6c, 0x6f, 0x5f, 0x63, 0x6f, 0x6e,
+	0x6e, 0x65, 0x63, 0x74, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f,
+	// package = "ligolo"
+	0x12, 0x06, 0x6c, 0x69, 0x67, 0x6f, 0x6c, 0x6f,
+	// message ConnectAgentReq { ... }  (43 bytes)
+	0x22, 0x2b,
+	// name = "ConnectAgentReq"
+	0x0a, 0x0f, 0x43, 0x6f, 0x6e, 0x6e, 0x65, 0x63, 0x74, 0x41, 0x67, 0x65,
+	0x6e, 0x74, 0x52, 0x65, 0x71,
+	// field: Address (24 bytes)
+	0x12, 0x18,
+	// name = "Address"
+	0x0a, 0x07, 0x41, 0x64, 0x64, 0x72, 0x65, 0x73, 0x73,
+	// number = 1
+	0x18, 0x01,
+	// label = LABEL_OPTIONAL
+	0x20, 0x01,
+	// type = TYPE_STRING
+	0x28, 0x09,
+	// json_name = "address"
+	0x52, 0x07, 0x61, 0x64, 0x64, 0x72, 0x65, 0x73, 0x73,
+	// options (44 bytes)
+	0x42, 0x2c,
+	// go_package = "github.com/ttpreport/ligolo-mp/v2/protobuf"
+	0x5a, 0x2a,
+	0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x74,
+	0x74, 0x70, 0x72, 0x65, 0x70, 0x6f, 0x72, 0x74, 0x2f, 0x6c, 0x69, 0x67,
+	0x6f, 0x6c, 0x6f, 0x2d, 0x6d, 0x70, 0x2f, 0x76, 0x32, 0x2f, 0x70, 0x72,
+	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66,
+	// syntax = "proto3"
+	0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+}
+
+var (
+	file_ligolo_connect_proto_rawDescOnce sync.Once
+	file_ligolo_connect_proto_rawDescData []byte
+)
+
+func file_ligolo_connect_proto_rawDescGZIP() []byte {
+	file_ligolo_connect_proto_rawDescOnce.Do(func() {
+		file_ligolo_connect_proto_rawDescData = file_ligolo_connect_proto_rawDesc
+		file_ligolo_connect_proto_rawDescData = protoimpl.X.CompressGZIP(file_ligolo_connect_proto_rawDescData)
+	})
+	return file_ligolo_connect_proto_rawDescData
+}
+
+var file_ligolo_connect_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
+var file_ligolo_connect_proto_goTypes = []interface{}{
+	(*ConnectAgentReq)(nil), // 0: ligolo.ConnectAgentReq
+}
+var file_ligolo_connect_proto_depIdxs = []int32{
+	0, // [0:0] is the sub-list for method output_type
+	0, // [0:0] is the sub-list for method input_type
+	0, // [0:0] is the sub-list for extension type_name
+	0, // [0:0] is the sub-list for extension extendee
+	0, // [0:0] is the sub-list for field type_name
+}
+
+var File_ligolo_connect_proto protoreflect.FileDescriptor
+
+// ConnectAgentReq is the request message for the ConnectAgent RPC.
+type ConnectAgentReq struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Address string `protobuf:"bytes,1,opt,name=Address,proto3" json:"Address,omitempty"`
+}
+
+func (x *ConnectAgentReq) Reset() {
+	*x = ConnectAgentReq{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_ligolo_connect_proto_msgTypes[0]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *ConnectAgentReq) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ConnectAgentReq) ProtoMessage() {}
+
+func (x *ConnectAgentReq) ProtoReflect() protoreflect.Message {
+	mi := &file_ligolo_connect_proto_msgTypes[0]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (*ConnectAgentReq) Descriptor() ([]byte, []int) {
+	return file_ligolo_connect_proto_rawDescGZIP(), []int{0}
+}
+
+func (x *ConnectAgentReq) GetAddress() string {
+	if x != nil {
+		return x.Address
+	}
+	return ""
+}
+
+func init() { file_ligolo_connect_proto_init() }
+
+func file_ligolo_connect_proto_init() {
+	if File_ligolo_connect_proto != nil {
+		return
+	}
+	if !protoimpl.UnsafeEnabled {
+		file_ligolo_connect_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*ConnectAgentReq); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+	}
+	type x struct{}
+	out := protoimpl.TypeBuilder{
+		File: protoimpl.DescBuilder{
+			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
+			RawDescriptor: file_ligolo_connect_proto_rawDesc,
+			NumEnums:      0,
+			NumMessages:   1,
+			NumExtensions: 0,
+			NumServices:   0,
+		},
+		GoTypes:           file_ligolo_connect_proto_goTypes,
+		DependencyIndexes: file_ligolo_connect_proto_depIdxs,
+		MessageInfos:      file_ligolo_connect_proto_msgTypes,
+	}.Build()
+	File_ligolo_connect_proto = out.File
+	file_ligolo_connect_proto_rawDesc = nil
+	file_ligolo_connect_proto_goTypes = nil
+	file_ligolo_connect_proto_depIdxs = nil
+}

--- a/protobuf/ligolo_grpc.pb.go
+++ b/protobuf/ligolo_grpc.pb.go
@@ -19,6 +19,7 @@ import (
 const _ = grpc.SupportPackageIsVersion7
 
 const (
+	Ligolo_ConnectAgent_FullMethodName    = "/ligolo.Ligolo/ConnectAgent"
 	Ligolo_Join_FullMethodName            = "/ligolo.Ligolo/Join"
 	Ligolo_GetMetadata_FullMethodName     = "/ligolo.Ligolo/GetMetadata"
 	Ligolo_GetSessions_FullMethodName     = "/ligolo.Ligolo/GetSessions"
@@ -71,6 +72,7 @@ type LigoloClient interface {
 	DemoteOperator(ctx context.Context, in *DemoteOperatorReq, opts ...grpc.CallOption) (*Empty, error)
 	GenerateAgent(ctx context.Context, in *GenerateAgentReq, opts ...grpc.CallOption) (*GenerateAgentResp, error)
 	Traceroute(ctx context.Context, in *TracerouteReq, opts ...grpc.CallOption) (*TracerouteResp, error)
+	ConnectAgent(ctx context.Context, in *ConnectAgentReq, opts ...grpc.CallOption) (*Empty, error)
 }
 
 type ligoloClient struct {
@@ -311,6 +313,15 @@ func (c *ligoloClient) Traceroute(ctx context.Context, in *TracerouteReq, opts .
 	return out, nil
 }
 
+func (c *ligoloClient) ConnectAgent(ctx context.Context, in *ConnectAgentReq, opts ...grpc.CallOption) (*Empty, error) {
+	out := new(Empty)
+	err := c.cc.Invoke(ctx, Ligolo_ConnectAgent_FullMethodName, in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // LigoloServer is the server API for Ligolo service.
 // All implementations must embed UnimplementedLigoloServer
 // for forward compatibility
@@ -338,6 +349,7 @@ type LigoloServer interface {
 	DemoteOperator(context.Context, *DemoteOperatorReq) (*Empty, error)
 	GenerateAgent(context.Context, *GenerateAgentReq) (*GenerateAgentResp, error)
 	Traceroute(context.Context, *TracerouteReq) (*TracerouteResp, error)
+	ConnectAgent(context.Context, *ConnectAgentReq) (*Empty, error)
 	mustEmbedUnimplementedLigoloServer()
 }
 
@@ -413,6 +425,9 @@ func (UnimplementedLigoloServer) GenerateAgent(context.Context, *GenerateAgentRe
 }
 func (UnimplementedLigoloServer) Traceroute(context.Context, *TracerouteReq) (*TracerouteResp, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Traceroute not implemented")
+}
+func (UnimplementedLigoloServer) ConnectAgent(context.Context, *ConnectAgentReq) (*Empty, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ConnectAgent not implemented")
 }
 func (UnimplementedLigoloServer) mustEmbedUnimplementedLigoloServer() {}
 
@@ -844,6 +859,24 @@ func _Ligolo_Traceroute_Handler(srv interface{}, ctx context.Context, dec func(i
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Ligolo_ConnectAgent_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ConnectAgentReq)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(LigoloServer).ConnectAgent(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Ligolo_ConnectAgent_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(LigoloServer).ConnectAgent(ctx, req.(*ConnectAgentReq))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // Ligolo_ServiceDesc is the grpc.ServiceDesc for Ligolo service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -938,6 +971,10 @@ var Ligolo_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Traceroute",
 			Handler:    _Ligolo_Traceroute_Handler,
+		},
+		{
+			MethodName: "ConnectAgent",
+			Handler:    _Ligolo_ConnectAgent_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{


### PR DESCRIPTION
### Bind agent #36 

Added `--bind <addr>` flag to the agent so it can listen instead of connecting to the server

```
agent --bind 0.0.0.0:11601
```

On the server side, `Ctrl+B` in the dashboard and enter the agent's address

### Version display #32

added `--version` flag

### CA regeneration fix #21

added `--rotate-pki` flag to regenerate all certificates (CA + server certs)

<img width="777" height="559" alt="Screenshot 2026-04-09 094152" src="https://github.com/user-attachments/assets/47e312c6-83e9-421c-871d-8b2f78b43b99" />
<img width="2559" height="1259" alt="Screenshot 2026-04-09 092816" src="https://github.com/user-attachments/assets/1c51efcb-59b2-4f38-aa36-ce3ea0c5fc62" />
<img width="1099" height="415" alt="Screenshot 2026-04-09 092830" src="https://github.com/user-attachments/assets/684099b2-5aa1-4583-97d1-c0f25d733c2a" />
<img width="2542" height="1286" alt="Screenshot 2026-04-09 093932" src="https://github.com/user-attachments/assets/a9fd0e03-27f4-4364-994f-a7d988a07941" />


