### PR TITLE
added regenerate all certificates option

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -27,6 +27,7 @@ func main() {
 	var maxConnectionHandler = flag.Int("max-connection", 1024, "per tunnel connection pool size")
 	var operatorAddr = flag.String("operator-addr", "0.0.0.0:58008", "Address for operators connections")
 	var insecureAgents = flag.Bool("insecure-agents", false, "Disable certificate verification for agents (insecure!)")
+	var regenCerts = flag.Bool("rotate-pki", false, "regenerate all certificates (CA + server certs)")
 
 	flag.Parse()
 
@@ -90,6 +91,18 @@ func main() {
 
 	crlService := crl.NewCRLService(crlRepo)
 	certService := certificate.NewCertificateService(certRepo, crlService)
+
+	if *regenCerts {
+		fmt.Println("Regenerating all certificates...")
+		if err := certService.RegenerateAll(); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println("Done. All server certificates have been regenerated.")
+		fmt.Println("WARNING: All existing operator profiles are now invalid and must be re-exported.")
+		os.Exit(0)
+	}
+
 	sessService := session.NewSessionService(cfg, sessRepo)
 	operService := operator.NewOperatorService(cfg, operRepo, certService)
 	assetService := asset.NewAssetsService(cfg, assetRepo)

--- a/internal/certificate/service.go
+++ b/internal/certificate/service.go
@@ -84,6 +84,19 @@ func (cs *CertificateService) RegenerateCert(name string) (*Certificate, error) 
 	return cert, nil
 }
 
+func (cs *CertificateService) RegenerateAll() error {
+	certs, err := cs.repo.GetAll()
+	if err != nil {
+		return err
+	}
+	for _, cert := range certs {
+		if err := cs.repo.Remove(cert.Name); err != nil {
+			return err
+		}
+	}
+	return cs.Init()
+}
+
 func (cs *CertificateService) Init() error {
 	CAcert, err := cs.GetCA()
 	if err != nil {


### PR DESCRIPTION
Rotate PKI `--rotate-pki` flag  closes #21

```sh
ligolo-mp -rotate-pki
```
- The flag exits immediately after regeneration — the server does not start
- All existing operator profiles become invalid after rotation and must be re-exported